### PR TITLE
fix newline code and delete not using contents

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -34,7 +34,7 @@ ja: &DEFAULT_JA
         desc: "Minecraftサーバーで、視聴者参加型のテストプレイを開催します。"
         icon: fas fa-cube
       - title: "生活鯖"
-        desc: "沼Labの人たちが生活しているMinecraftサーバー\n鯖の詳細はDiscordサーバー内で！"
+        desc: "沼Labの人たちが生活しているMinecraftサーバー<br>鯖の詳細はDiscordサーバー内で！"
         icon: fas fa-home
   portfolio:
     title: "制作"
@@ -122,24 +122,6 @@ ja: &DEFAULT_JA
         # you can enforce the alignment
         # align: right
     end: "まだ沼Labは <br> 始まった <br> ばかりだ!"
-
-  clients:
-    section: clients
-    max-height: 100px
-    horizontal-scrolling: "" #"yes/no"
-    list:
-      - title: "envato"
-        url: https://github.com/raviriley/agency-jekyll-theme
-        logo: assets/img/clients/envato.webp
-      - title: "designmodo"
-        url: https://github.com/raviriley/agency-jekyll-theme
-        logo: assets/img/clients/designmodo.webp
-      - title: "themeforest"
-        url: https://github.com/raviriley/agency-jekyll-theme
-        logo: assets/img/clients/themeforest.webp
-      - title: "Creative Market"
-        url: https://github.com/raviriley/agency-jekyll-theme
-        logo: assets/img/clients/creative-market.webp
 
   footer:
     social:


### PR DESCRIPTION
## 内容
- #12 で追加された生活鯖の紹介文にある改行コードが表面上では反映されないためbrに変更。
- sitetext.yml内にて利用していないclientsセクションのコードを削除。

## プレビューリンク
https://12c03944.www-numalab-net.pages.dev
