### PR TITLE
chnage iframe height

### DIFF
--- a/_includes/discord.html
+++ b/_includes/discord.html
@@ -1,15 +1,15 @@
 <!-- Discord Section -->
-    <section class="page-section" id="discord" style="background-color: #f8f9fa;">
-	<div class="container">
-		<div class="row">
-			<div class="col-lg-12 text-center">
-				<h2 class="section-heading text-uppercase">Discordサーバー</h2>
-				<h3 class="section-subheading text-muted">沼LabのDiscordサーバーができました！</h3>
-			</div>
-		</div>
-		<div style="text-align: center;">
-			<iframe src="https://discord.com/widget?id=930083398691733565&theme=dark" width="75%" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
-		</div>
-	</div>
+<section class="page-section" id="discord" style="background-color: #f8f9fa;">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12 text-center">
+        <h2 class="section-heading text-uppercase">Discordサーバー</h2>
+        <h3 class="section-subheading text-muted">沼LabのDiscordサーバーができました！</h3>
+      </div>
+    </div>
+    <div style="text-align: center;">
+      <iframe src="https://discord.com/widget?id=930083398691733565&theme=dark" width="75%" height="600" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+    </div>
+  </div>
 </section>
 


### PR DESCRIPTION
## Issue番号
- close #21 

## 内容
上記Issueへの簡単な対応。
他のセクションの高さと比べたが、他のセクションと高さに差がないのでたまたまこのセクションだけで発生していることに気づいただけだと思う。なので、他のセクションでもこのIssueの内容は発生する。
今回は、discord widget のiframeの高さを100大きくするだけの対応にした。
あと、インデント位置が全体的に悪いので`discord.html`だけきれいにした。

## プレビューリンク
https://611ea303.www-numalab-net.pages.dev/